### PR TITLE
Uncomment the panics

### DIFF
--- a/cipher/address.go
+++ b/cipher/address.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/skycoin/skycoin-lite/cipher/base58"
 )
@@ -64,7 +65,7 @@ func DecodeBase58Address(addr string) (Address, error) {
 func MustDecodeBase58Address(addr string) Address {
 	a, err := DecodeBase58Address(addr)
 	if err != nil {
-		//logger.Panicf("Invalid address %s: %v", addr, err)
+		log.Panicf("Invalid address %s: %v", addr, err)
 	}
 	return a
 }
@@ -82,7 +83,7 @@ func BitcoinDecodeBase58Address(addr string) (Address, error) {
 func BitcoinMustDecodeBase58Address(addr string) Address {
 	a, err := BitcoinDecodeBase58Address(addr)
 	if err != nil {
-		//logger.Panicf("Invalid address %s: %v", addr, err)
+		log.Panicf("Invalid address %s: %v", addr, err)
 	}
 	return a
 }
@@ -261,7 +262,7 @@ func SecKeyFromWalletImportFormat(input string) (SecKey, error) {
 
 	seckey := b[1:33]
 	if len(seckey) != 32 {
-		//logger.Panic("...")
+		log.Panic("...")
 	}
 	return NewSecKey(b[1:33]), nil
 }
@@ -270,7 +271,7 @@ func SecKeyFromWalletImportFormat(input string) (SecKey, error) {
 func MustSecKeyFromWalletImportFormat(input string) SecKey {
 	seckey, err := SecKeyFromWalletImportFormat(input)
 	if err != nil {
-		//logger.Panicf("MustSecKeyFromWalletImportFormat, invalid seckey, %v", err)
+		log.Panicf("MustSecKeyFromWalletImportFormat, invalid seckey, %v", err)
 	}
 	return seckey
 }

--- a/cipher/crypto.go
+++ b/cipher/crypto.go
@@ -52,7 +52,7 @@ func RandByte(n int) []byte {
 func NewPubKey(b []byte) PubKey {
 	p := PubKey{}
 	if len(b) != len(p) {
-		//logger.Panic("Invalid public key length")
+		log.Panic("Invalid public key length")
 	}
 	copy(p[:], b[:])
 	return p
@@ -62,7 +62,7 @@ func NewPubKey(b []byte) PubKey {
 func MustPubKeyFromHex(s string) PubKey {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		//logger.Panic(err)
+		log.Panic(err)
 	}
 	return NewPubKey(b)
 }
@@ -79,12 +79,12 @@ func PubKeyFromHex(s string) (PubKey, error) {
 // PubKeyFromSecKey recovers the public key for a secret key
 func PubKeyFromSecKey(seckey SecKey) PubKey {
 	if seckey == (SecKey{}) {
-		//logger.Panic("PubKeyFromSecKey, attempt to load null seckey, unsafe")
+		log.Panic("PubKeyFromSecKey, attempt to load null seckey, unsafe")
 	}
 	b := secp256k1.PubkeyFromSeckey(seckey[:])
 	if b == nil {
-		//logger.Panic("PubKeyFromSecKey, pubkey recovery failed. Function " +
-		//	"assumes seckey is valid. Check seckey")
+		log.Panic("PubKeyFromSecKey, pubkey recovery failed. Function " +
+			"assumes seckey is valid. Check seckey")
 	}
 	return NewPubKey(b)
 }
@@ -125,7 +125,7 @@ type SecKey [32]byte
 func NewSecKey(b []byte) SecKey {
 	p := SecKey{}
 	if len(b) != len(p) {
-		//logger.Panic("Invalid secret key length")
+		log.Panic("Invalid secret key length")
 	}
 	copy(p[:], b[:])
 	return p
@@ -135,7 +135,7 @@ func NewSecKey(b []byte) SecKey {
 func MustSecKeyFromHex(s string) SecKey {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		//logger.Panic(err)
+		log.Panic(err)
 	}
 	return NewSecKey(b)
 }
@@ -161,7 +161,7 @@ func (sk SecKey) Verify() error {
 	if DebugLevel2 {
 		err := TestSecKey(sk)
 		if err != nil {
-			//logger.Panic("DebugLevel2, WARNING CRYPTO ARMAGEDDON")
+			log.Panic("DebugLevel2, WARNING CRYPTO ARMAGEDDON")
 		}
 	}
 	return nil
@@ -184,11 +184,11 @@ func (sk SecKey) Hex() string {
 func ECDH(pub PubKey, sec SecKey) []byte {
 
 	if err := pub.Verify(); err != nil {
-		//logger.Panic("ECDH invalid pubkey input")
+		log.Panic("ECDH invalid pubkey input")
 	}
 
 	if err := sec.Verify(); err != nil {
-		//logger.Panic("ECDH invalid seckey input")
+		log.Panic("ECDH invalid seckey input")
 	}
 
 	buff := secp256k1.ECDH(pub[:], sec[:])
@@ -204,7 +204,7 @@ type Sig [64 + 1]byte //64 byte signature with 1 byte for key recovery
 func NewSig(b []byte) Sig {
 	s := Sig{}
 	if len(b) != len(s) {
-		//logger.Panic("Invalid secret key length")
+		log.Panic("Invalid secret key length")
 	}
 	copy(s[:], b[:])
 	return s
@@ -214,10 +214,10 @@ func NewSig(b []byte) Sig {
 func MustSigFromHex(s string) Sig {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		//logger.Panic(err)
+		log.Panic(err)
 	}
 	if len(b) != 65 {
-		//logger.Panic("Signature Length is Invalid")
+		log.Panic("Signature Length is Invalid")
 	}
 	return NewSig(b)
 }
@@ -246,14 +246,14 @@ func SignHash(hash SHA256, sec SecKey) Sig {
 	if DebugLevel2 || DebugLevel1 { //!!! Guard against coin loss
 		pubkey, err := PubKeyFromSig(sig, hash)
 		if err != nil {
-			//logger.Panic("SignHash, error: pubkey from sig recovery failure")
+			log.Panic("SignHash, error: pubkey from sig recovery failure")
 		}
 		if VerifySignature(pubkey, sig, hash) != nil {
-			//logger.Panic("SignHash, error: secp256k1.Sign returned non-null " +
-			//	"invalid non-null signature")
+			log.Panic("SignHash, error: secp256k1.Sign returned non-null " +
+				"invalid non-null signature")
 		}
 		if ChkSig(AddressFromPubKey(pubkey), hash, sig) != nil {
-			//logger.Panic("SignHash error: ChkSig failed for signature")
+			log.Panic("SignHash error: ChkSig failed for signature")
 		}
 	}
 	return sig
@@ -307,7 +307,7 @@ func VerifySignature(pubkey PubKey, sig Sig, hash SHA256) error {
 	if secp256k1.VerifyPubkey(pubkey[:]) != 1 {
 		if DebugLevel2 {
 			if secp256k1.VerifySignature(hash[:], sig[:], pubkey[:]) == 1 {
-				//logger.Panic("VerifySignature warning, ")
+				log.Panic("VerifySignature warning, ")
 			}
 		}
 		return errors.New("VerifySignature, secp256k1.VerifyPubkey failed")
@@ -327,8 +327,8 @@ func GenerateKeyPair() (PubKey, SecKey) {
 
 	if DebugLevel1 {
 		if TestSecKey(NewSecKey(secret)) != nil {
-			//logger.Panic("DebugLevel1, GenerateKeyPair, generated private key " +
-			//	"failed TestSecKey")
+			log.Panic("DebugLevel1, GenerateKeyPair, generated private key " +
+				"failed TestSecKey")
 		}
 	}
 
@@ -342,20 +342,20 @@ func GenerateDeterministicKeyPair(seed []byte) (PubKey, SecKey) {
 	if DebugLevel1 {
 
 		if TestSecKey(NewSecKey(secret)) != nil {
-			//logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
-			//	"seckey invalid, failed TestSecKey")
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+				"seckey invalid, failed TestSecKey")
 		}
 		if TestSecKey(NewSecKey(secret)) != nil {
-			//logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
-			//	"generated private key failed TestSecKey")
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+				"generated private key failed TestSecKey")
 		}
 		if PubKeyFromSecKey(NewSecKey(secret)) != NewPubKey(public) {
 			//s1 := NewSecKey(secret).Hex()
 			//s2 := NewPubKey(public).Hex()
 			//s3 := PubKeyFromSecKey(NewSecKey(secret)).Hex()
 			//log.Printf("sec= %s, pub= %s recpub= %s \n", s1,s2, s3 )
-			//logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
-			//	"public key does not match private key")
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+				"public key does not match private key")
 		}
 	}
 	return NewPubKey(public), NewSecKey(secret)
@@ -368,12 +368,12 @@ func DeterministicKeyPairIterator(seed []byte) ([]byte, PubKey, SecKey) {
 	hash, public, secret := secp256k1.DeterministicKeyPairIterator(seed)
 	if DebugLevel1 {
 		if TestSecKey(NewSecKey(secret)) != nil {
-			//logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
-			//	"generated private key failed TestSecKey")
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+				"generated private key failed TestSecKey")
 		}
 		if PubKeyFromSecKey(NewSecKey(secret)) != NewPubKey(public) {
-			//logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
-			//	"public key does not match private key")
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+				"public key does not match private key")
 		}
 	}
 	return hash, NewPubKey(public), NewSecKey(secret)

--- a/coin/transactions.go
+++ b/coin/transactions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"log"
 
 	"github.com/skycoin/skycoin-lite/cipher"
 	"github.com/skycoin/skycoin-lite/cipher/encoder"
@@ -135,10 +136,10 @@ func (txn *Transaction) Verify() error {
 func (txn Transaction) VerifyInput(uxIn UxArray) error {
 	if DebugLevel2 {
 		if len(txn.In) != len(txn.Sigs) || len(txn.In) != len(uxIn) {
-			//logger.Panic("tx.In != tx.Sigs != uxIn")
+			log.Panic("tx.In != tx.Sigs != uxIn")
 		}
 		if txn.InnerHash != txn.HashInner() {
-			//logger.Panic("Invalid Tx Header Hash")
+			log.Panic("Invalid Tx Header Hash")
 		}
 	}
 
@@ -154,11 +155,11 @@ func (txn Transaction) VerifyInput(uxIn UxArray) error {
 		// Check that hashes match.
 		// This would imply a bug with UnspentPool.GetMultiple
 		if len(txn.In) != len(uxIn) {
-			//logger.Panic("tx.In does not match uxIn")
+			log.Panic("tx.In does not match uxIn")
 		}
 		for i := range txn.In {
 			if txn.In[i] != uxIn[i].Hash() {
-				//logger.Panic("impossible error: Ux hash mismatch")
+				log.Panic("impossible error: Ux hash mismatch")
 			}
 		}
 	}
@@ -169,7 +170,7 @@ func (txn Transaction) VerifyInput(uxIn UxArray) error {
 // Returns the signature index for later signing
 func (txn *Transaction) PushInput(uxOut cipher.SHA256) uint16 {
 	if len(txn.In) >= math.MaxUint16 {
-		//logger.Panic("Max transaction inputs reached")
+		log.Panic("Max transaction inputs reached")
 	}
 	txn.In = append(txn.In, uxOut)
 	return uint16(len(txn.In) - 1)
@@ -200,16 +201,16 @@ func (txn *Transaction) SignInputs(keys []cipher.SecKey) {
 	txn.InnerHash = txn.HashInner() //update hash
 
 	if len(txn.Sigs) != 0 {
-		//logger.Panic("Transaction has been signed")
+		log.Panic("Transaction has been signed")
 	}
 	if len(keys) != len(txn.In) {
-		//logger.Panic("Invalid number of keys")
+		log.Panic("Invalid number of keys")
 	}
 	if len(keys) > math.MaxUint16 {
-		//logger.Panic("Too many key")
+		log.Panic("Too many key")
 	}
 	if len(keys) == 0 {
-		//logger.Panic("No keys")
+		log.Panic("No keys")
 	}
 	sigs := make([]cipher.Sig, len(txn.In))
 	innerHash := txn.HashInner()
@@ -274,7 +275,7 @@ func (txn *Transaction) Serialize() []byte {
 func MustTransactionDeserialize(b []byte) Transaction {
 	t, err := TransactionDeserialize(b)
 	if err != nil {
-		//logger.Panicf("Failed to deserialize transaction: %v", err)
+		log.Panicf("Failed to deserialize transaction: %v", err)
 	}
 	return t
 }


### PR DESCRIPTION
Many of the panics on several files were commented, which let the door open for various types of errors. For example, https://github.com/skycoin/skycoin-web/issues/60 happens when an invalid address is entered, because the panic is ignored and execution continues. This pr, after running gopherjs and replacing the js file in the web wallet, causes the problem to be solved, by canceling the operation and showing an error like this:

![error](https://user-images.githubusercontent.com/34079003/40199589-01dfe6f2-59e8-11e8-9ef4-63ca0adb7b94.png)
