### PR TITLE
Use panic to return error messages

### DIFF
--- a/liteclient/client.go
+++ b/liteclient/client.go
@@ -3,7 +3,6 @@ package liteclient
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
@@ -32,24 +31,19 @@ type TransactionOutput struct {
 }
 
 // GenerateAddress generates an address from a seed. The seed should be hex-encoded bytes.
-func GenerateAddress(seed string) (Address, error) {
-	addrs, err := GenerateAddresses(seed, 1)
-	if err != nil {
-		return Address{}, err
-	}
-
-	return addrs[0], nil
+func GenerateAddress(seed string) Address {
+	return GenerateAddresses(seed, 1)[0]
 }
 
 // GenerateAddresses generates addresses from a seed. The seed should be hex-encoded bytes.
-func GenerateAddresses(seed string, num int) ([]Address, error) {
+func GenerateAddresses(seed string, num int) []Address {
 	addresses := make([]Address, num)
 
 	nextSeed := seed
 	for i := 0; i < num; i++ {
 		decodedSeed, err := hex.DecodeString(nextSeed)
 		if err != nil {
-			return nil, err
+			panic(err)
 		}
 
 		next, keys := cipher.GenerateDeterministicKeyPairsSeed([]byte(decodedSeed), 1)
@@ -65,21 +59,21 @@ func GenerateAddresses(seed string, num int) ([]Address, error) {
 		addresses[i] = address
 	}
 
-	return addresses, nil
+	return addresses
 }
 
 // PrepareTransaction receives inputs and outputs and returns a signed transaction
 // inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
-func PrepareTransaction(inputsBody string, outputsBody string) (string, error) {
+func PrepareTransaction(inputsBody string, outputsBody string) string {
 	var inputs []TransactionInput
 	var outputs []TransactionOutput
 
 	if err := json.Unmarshal([]byte(inputsBody), &inputs); err != nil {
-		return "", err
+		panic(err)
 	}
 
 	if err := json.Unmarshal([]byte(outputsBody), &outputs); err != nil {
-		return "", err
+		panic(err)
 	}
 
 	newTransaction := coin.Transaction{}
@@ -89,12 +83,12 @@ func PrepareTransaction(inputsBody string, outputsBody string) (string, error) {
 	for i, in := range inputs {
 		k, err := cipher.SecKeyFromHex(in.Secret)
 		if err != nil {
-			return "", err
+			panic(err)
 		}
 
 		inputHash, err := cipher.SHA256FromHex(in.Hash)
 		if err != nil {
-			return "", err
+			panic(err)
 		}
 
 		keys[i] = k
@@ -104,11 +98,11 @@ func PrepareTransaction(inputsBody string, outputsBody string) (string, error) {
 	for _, out := range outputs {
 		addr, err := cipher.DecodeBase58Address(out.Address)
 		if err != nil {
-			return "", err
+			panic(err)
 		}
 
 		if addr.Null() {
-			return "", errors.New("output address is the null address")
+			panic("output address is the null address")
 		}
 
 		newTransaction.PushOutput(addr, out.Coins, out.Hours)
@@ -118,10 +112,10 @@ func PrepareTransaction(inputsBody string, outputsBody string) (string, error) {
 	newTransaction.UpdateHeader()
 
 	if err := newTransaction.Verify(); err != nil {
-		return "", err
+		panic(err)
 	}
 
 	d := newTransaction.Serialize()
 
-	return hex.EncodeToString(d), nil
+	return hex.EncodeToString(d)
 }

--- a/main.go
+++ b/main.go
@@ -11,34 +11,18 @@ import (
 func main() {
 	seed := hex.EncodeToString([]byte("nest*"))
 
-	addrs, err := liteclient.GenerateAddresses(seed, 3)
-	if err != nil {
-		fmt.Println("ERROR:", err)
-	} else {
-		fmt.Println(addrs)
-	}
+	addrs := liteclient.GenerateAddresses(seed, 3)
+	fmt.Println(addrs)
 
-	address1, err := liteclient.GenerateAddress(seed)
+	address1 := liteclient.GenerateAddress(seed)
 	fmt.Println("----")
-	if err != nil {
-		fmt.Println("ERROR:", err)
-	} else {
-		fmt.Println(address1)
-	}
+	fmt.Println(address1)
 
-	address2, err := liteclient.GenerateAddress(address1.NextSeed)
+	address2 := liteclient.GenerateAddress(address1.NextSeed)
 	fmt.Println("----")
-	if err != nil {
-		fmt.Println("ERROR:", err)
-	} else {
-		fmt.Println(address2)
-	}
+	fmt.Println(address2)
 
-	address3, err := liteclient.GenerateAddress(address2.NextSeed)
+	address3 := liteclient.GenerateAddress(address2.NextSeed)
 	fmt.Println("----")
-	if err != nil {
-		fmt.Println("ERROR:", err)
-	} else {
-		fmt.Println(address3)
-	}
+	fmt.Println(address3)
 }

--- a/mobile/api.go
+++ b/mobile/api.go
@@ -9,14 +9,11 @@ import (
 // GetAddresses returns a series of addresses based on a seed and the number of addresses
 // Seed is be hex-encoded bytes.
 func GetAddresses(seed string, amount int) (string, error) {
-	addresses, err := liteclient.GenerateAddresses(seed, amount)
-	if err != nil {
-		return "", err
-	}
+	addresses := liteclient.GenerateAddresses(seed, amount)
 
 	response, err := json.Marshal(addresses)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
 
 	return string(response), nil

--- a/skycoin/skycoin_test.go
+++ b/skycoin/skycoin_test.go
@@ -11,10 +11,7 @@ func TestGenerateAddress(t *testing.T) {
 	stringSeed := "abcdefg"
 	seed := hex.EncodeToString([]byte(stringSeed))
 
-	addr, err := liteclient.GenerateAddress(seed)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	addr := liteclient.GenerateAddress(seed)
 
 	if addr.Address != "gyJNKKj95bCn6o5mUCQgz8SCem7av2W3CG" {
 		t.Fatalf("GenerateAddress address is invalid")
@@ -24,10 +21,7 @@ func TestGenerateAddress(t *testing.T) {
 		t.Fatalf("GenerateAddress pubkey is invalid")
 	}
 
-	nextAddr, err := liteclient.GenerateAddress(addr.NextSeed)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	nextAddr := liteclient.GenerateAddress(addr.NextSeed)
 
 	if nextAddr.Address != "2YzQDZFpS64u5ydnE9iKK9WJPXU2EbmSzmW" {
 		t.Fatalf("GenerateAddress address is invalid 2")


### PR DESCRIPTION
Fixes #15 

Changes:
- The functions of `liteclient/client.go` now only return one value and, in case of error, use `panic(err)`.
- The unit test was adapted to the changes (`skycoin_test.go`).
- The file for the mobile library (`mobile/api.go`) was adapted to the changes.
- The test file (`./main.go`) was adapted to the changes.

The use of panics should not adversely affect the mobile version, since Go Mobile converts panics into exceptions, like gopherjs: 
https://github.com/golang/go/blob/33cfcf6afac867f4fbf94237b9219778e5fd51c7/src/runtime/runtime1.go#L413-L417