### PR TITLE
Expose more function for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install-linters: ## Install linters
 	gometalinter --vendored-linters --install
 
 format: ## Formats the code. Must have goimports installed (use make install-linters).
-	goimports -w ./gopher
+	goimports -w ./skycoin
 	goimports -w ./liteclient
 	goimports -w ./mobile
 

--- a/liteclient/extras.go
+++ b/liteclient/extras.go
@@ -74,7 +74,7 @@ func AddressFromSecKey(seckey string) string {
 func PubKeyFromSig(sig string, hash string) string {
 	s := cipher.MustSigFromHex(sig)
 	h := cipher.MustSHA256FromHex(hash)
-	
+
 	pubKey, err := cipher.PubKeyFromSig(s, h)
 	if err != nil {
 		panic(err)

--- a/liteclient/extras.go
+++ b/liteclient/extras.go
@@ -1,0 +1,93 @@
+package liteclient
+
+import (
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
+)
+
+/*
+Functions used mainly during test procedures.
+*/
+
+// VerifySignature verifies that hash was signed by PubKey
+func VerifySignature(pubkey string, sig string, hash string) {
+	p := cipher.MustPubKeyFromHex(pubkey)
+	s := cipher.MustSigFromHex(sig)
+	h := cipher.MustSHA256FromHex(hash)
+
+	err := cipher.VerifySignature(p, s, h)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ChkSig checks whether PubKey corresponding to address hash signed hash
+func ChkSig(address string, hash string, sig string) {
+	a := cipher.MustDecodeBase58Address(address)
+	h := cipher.MustSHA256FromHex(hash)
+	s := cipher.MustSigFromHex(sig)
+
+	err := cipher.ChkSig(a, h, s)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// VerifySignedHash this only checks that the signature can be converted to a public key
+// Since there is no pubkey or address argument, it cannot check that the
+// signature is valid in that context.
+func VerifySignedHash(sig string, hash string) {
+	s := cipher.MustSigFromHex(sig)
+	h := cipher.MustSHA256FromHex(hash)
+
+	err := cipher.VerifySignedHash(s, h)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// VerifySeckey validate a private key
+func VerifySeckey(seckey string) int {
+	s := cipher.MustSecKeyFromHex(seckey)
+	return secp256k1.VerifySeckey(s[:])
+}
+
+// VerifyPubkey validate a public key
+func VerifyPubkey(pubkey string) int {
+	p := cipher.MustPubKeyFromHex(pubkey)
+	return secp256k1.VerifyPubkey(p[:])
+}
+
+// AddressFromPubKey creates Address from PubKey as ripemd160(sha256(sha256(pubkey)))
+func AddressFromPubKey(pubkey string) string {
+	p := cipher.MustPubKeyFromHex(pubkey)
+	return cipher.AddressFromPubKey(p).String()
+}
+
+// AddressFromSecKey generates address from secret key
+func AddressFromSecKey(seckey string) string {
+	s := cipher.MustSecKeyFromHex(seckey)
+	return cipher.AddressFromSecKey(s).String()
+}
+
+// PubKeyFromSig recovers the public key from a signed hash
+func PubKeyFromSig(sig string, hash string) string {
+	s := cipher.MustSigFromHex(sig)
+	h := cipher.MustSHA256FromHex(hash)
+	
+	pubKey, err := cipher.PubKeyFromSig(s, h)
+	if err != nil {
+		panic(err)
+	}
+
+	return pubKey.Hex()
+}
+
+// SignHash sign hash
+func SignHash(hash string, seckey string) string {
+	h := cipher.MustSHA256FromHex(hash)
+	s := cipher.MustSecKeyFromHex(seckey)
+
+	sig := cipher.SignHash(h, s)
+	return sig.Hex()
+}

--- a/skycoin/skycoin.go
+++ b/skycoin/skycoin.go
@@ -12,14 +12,14 @@ func main() {
 	})
 
 	js.Global.Set("CipherExtras", map[string]interface{}{
-		"VerifySignature":  liteclient.VerifySignature,
-		"ChkSig": liteclient.ChkSig,
-		"VerifySignedHash": liteclient.VerifySignedHash,
-		"VerifySeckey": liteclient.VerifySeckey,
-		"VerifyPubkey": liteclient.VerifyPubkey,
+		"VerifySignature":   liteclient.VerifySignature,
+		"ChkSig":            liteclient.ChkSig,
+		"VerifySignedHash":  liteclient.VerifySignedHash,
+		"VerifySeckey":      liteclient.VerifySeckey,
+		"VerifyPubkey":      liteclient.VerifyPubkey,
 		"AddressFromPubKey": liteclient.AddressFromPubKey,
 		"AddressFromSecKey": liteclient.AddressFromSecKey,
-		"PubKeyFromSig": liteclient.PubKeyFromSig,
-		"SignHash": liteclient.SignHash,
+		"PubKeyFromSig":     liteclient.PubKeyFromSig,
+		"SignHash":          liteclient.SignHash,
 	})
 }

--- a/skycoin/skycoin.go
+++ b/skycoin/skycoin.go
@@ -10,4 +10,16 @@ func main() {
 		"GenerateAddresses":  liteclient.GenerateAddress,
 		"PrepareTransaction": liteclient.PrepareTransaction,
 	})
+
+	js.Global.Set("CipherExtras", map[string]interface{}{
+		"VerifySignature":  liteclient.VerifySignature,
+		"ChkSig": liteclient.ChkSig,
+		"VerifySignedHash": liteclient.VerifySignedHash,
+		"VerifySeckey": liteclient.VerifySeckey,
+		"VerifyPubkey": liteclient.VerifyPubkey,
+		"AddressFromPubKey": liteclient.AddressFromPubKey,
+		"AddressFromSecKey": liteclient.AddressFromSecKey,
+		"PubKeyFromSig": liteclient.PubKeyFromSig,
+		"SignHash": liteclient.SignHash,
+	})
 }

--- a/skycoin/skycoin_test.go
+++ b/skycoin/skycoin_test.go
@@ -73,5 +73,5 @@ func TestGenerateAddress(t *testing.T) {
 	if signHash == "" {
 		t.Fatalf("created signature is null")
 	}
-	
+
 }

--- a/skycoin/skycoin_test.go
+++ b/skycoin/skycoin_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestGenerateAddress(t *testing.T) {
+
+	//client.go
+
 	stringSeed := "abcdefg"
 	seed := hex.EncodeToString([]byte(stringSeed))
 
@@ -30,4 +33,45 @@ func TestGenerateAddress(t *testing.T) {
 	if nextAddr.Public != "023ea091a649aef9d8fe5b956bd5cf2a9e47b8a7ba41f8b83997de0d1b1a851e73" {
 		t.Fatalf("GenerateAddress pubkey is invalid 2")
 	}
+
+	//extras.go
+
+	pubkey := "037c4cff096a7219b17f8502b9ed643c947d5d4929c1a141b3240f70b60a15a7b8"
+	seckey := "697c7cfba3c6d13dc6bd3f063c60ef4d25de903e50fe8c5e123e5efb08e21e29"
+	address := "XZ9S3QKN5tSRVswDNE6GLCtTfm8DqRthyA"
+	signature := "ba85034f675b8a284537a0c23e4d55d5f8b4cc1620eee077a478482b8f7bf9304d17c16dd5aaf70d24df262c531f37e58a57469d1161d6134075ed8c203f7cbc01"
+	hash := "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+
+	liteclient.VerifySignature(pubkey, signature, hash)
+
+	liteclient.ChkSig(address, hash, signature)
+
+	liteclient.VerifySignedHash(signature, hash)
+
+	if liteclient.VerifySeckey(seckey) != 1 {
+		t.Fatalf("secp256k1.VerifySeckey failed")
+	}
+
+	if liteclient.VerifyPubkey(pubkey) != 1 {
+		t.Fatalf("secp256k1.VerifyPubkey failed")
+	}
+
+	if liteclient.AddressFromPubKey(pubkey) != address {
+		t.Fatalf("cipher.AddressFromPubKey failed")
+	}
+
+	if liteclient.AddressFromSecKey(seckey) != address {
+		t.Fatalf("cipher.AddressFromPubKey failed")
+	}
+
+	pubkey2 := liteclient.PubKeyFromSig(signature, hash)
+	if pubkey2 != pubkey {
+		t.Fatalf("cipher.AddressFromPubKey failed")
+	}
+
+	signHash := liteclient.SignHash(hash, seckey)
+	if signHash == "" {
+		t.Fatalf("created signature is null")
+	}
+	
 }


### PR DESCRIPTION
Currently the library only exposes 2 methods. Due to this, it is not possible to perform in JavaScript all the tests of the cipher test suit. This pr exposes the necessary functions to perform the tests of the `ValidateSeedData` function of the cipher test suite:
https://github.com/gz-c/skycoin/blob/461130cf73fc0119eb7819db6f5898a91a6b85ba/src/cipher/testsuite/testsuite.go#L166-L264

It includes some simple tests in `skycoin_test.go`, to ensure that there were no errors while exposing the functions. Also, it was compiled with goherjs and some simple tests in JavaScript were performed (the compiled file is not included in this pr).