### PR TITLE
Use the vendored gopherjs only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,11 @@ install:
   - make install-linters
   - npm install
   - npm install --global source-map-support
-  - go get github.com/gopherjs/gopherjs
-  - cd $GOPATH/src/github.com/gopherjs/gopherjs/node-syscall/
-  - npm install --global node-gyp
-  - node-gyp rebuild
-  - mkdir -p $HOME/.node_libraries/
-  - cp build/Release/syscall.node $HOME/.node_libraries/syscall.node
-  - cd -
 
 script:
   - make check
   - make build-js-min
   - make test-suite-ts
-  - NODE_PATH=$(npm root --global) make test-js
 
 notifications:
   # https://github.com/kvld/travisci-telegram TravisCI Telegram Bot integration


### PR DESCRIPTION
Due to the addition of the test suite that is responsible for performing deep checks to the compiled js library, `make test-js` is no longer necessary in Travis. The removal of `make test-js` from Travis makes it unnecessary to install gopherjs globally, so that part was also removed from Travis.

The point of this pr is that when trying to install gopherjs in Travis, an error occurred because the latest version of gopherjs requires Go 1.11.