### PR TITLE
Create transactions with signatures

### DIFF
--- a/liteclient/client.go
+++ b/liteclient/client.go
@@ -3,7 +3,6 @@ package liteclient
 import (
 	"encoding/hex"
 	"encoding/json"
-	"log"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
@@ -143,17 +142,7 @@ func buildTransaction(inputsBody string, outputsBody string, signatureList []str
 	} else {
 		newTransaction.Sigs = make([]cipher.Sig, len(signatureList))
 		for i, sig := range signatureList {
-			decodedSig, e := hex.DecodeString(sig)
-			if e != nil {
-				panic(e)
-			}
-
-			s := cipher.Sig{}
-			if len(decodedSig) != len(s) {
-				log.Panic("Invalid signature length")
-			}
-			copy(s[:], decodedSig[:])
-			newTransaction.Sigs[i] = s
+			newTransaction.Sigs[i] = cipher.MustSigFromHex(sig)
 		}
 	}
 	newTransaction.UpdateHeader()

--- a/liteclient/client.go
+++ b/liteclient/client.go
@@ -3,6 +3,7 @@ package liteclient
 import (
 	"encoding/hex"
 	"encoding/json"
+	"log"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
@@ -65,6 +66,32 @@ func GenerateAddresses(seed string, num int) []Address {
 // PrepareTransaction receives inputs and outputs and returns a signed transaction
 // inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
 func PrepareTransaction(inputsBody string, outputsBody string) string {
+	newTransaction := buildTransaction(inputsBody, outputsBody, nil)
+	d := newTransaction.Serialize()
+
+	return hex.EncodeToString(d)
+}
+
+// PrepareTransactionWithSignatures receives inputs, outputs,and the signatures and returns.
+// inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
+// signatureList is a JSONified array of strings.
+func PrepareTransactionWithSignatures(inputsBody string, outputsBody string, signatureList string) string {
+	var signatures []string
+	if err := json.Unmarshal([]byte(signatureList), &signatures); err != nil {
+		panic(err)
+	}
+
+	newTransaction := buildTransaction(inputsBody, outputsBody, signatures)
+	d := newTransaction.Serialize()
+
+	return hex.EncodeToString(d)
+}
+
+// Creates a coin.Transaction using the given lists of inputs, outputs and signatures. If signatureList is nill, the
+// signatures are created using the Secret property of each input.
+// inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
+// signatureList is a JSONified array of strings.
+func buildTransaction(inputsBody string, outputsBody string, signatureList []string) coin.Transaction {
 	var inputs []TransactionInput
 	var outputs []TransactionOutput
 
@@ -81,9 +108,13 @@ func PrepareTransaction(inputsBody string, outputsBody string) string {
 	keys := make([]cipher.SecKey, len(inputs))
 
 	for i, in := range inputs {
-		k, err := cipher.SecKeyFromHex(in.Secret)
-		if err != nil {
-			panic(err)
+		if signatureList == nil {
+			k, err := cipher.SecKeyFromHex(in.Secret)
+			if err != nil {
+				panic(err)
+			}
+
+			keys[i] = k
 		}
 
 		inputHash, err := cipher.SHA256FromHex(in.Hash)
@@ -91,7 +122,6 @@ func PrepareTransaction(inputsBody string, outputsBody string) string {
 			panic(err)
 		}
 
-		keys[i] = k
 		newTransaction.PushInput(inputHash)
 	}
 
@@ -108,14 +138,29 @@ func PrepareTransaction(inputsBody string, outputsBody string) string {
 		newTransaction.PushOutput(addr, out.Coins, out.Hours)
 	}
 
-	newTransaction.SignInputs(keys)
+	if signatureList == nil {
+		newTransaction.SignInputs(keys)
+	} else {
+		newTransaction.Sigs = make([]cipher.Sig, len(signatureList))
+		for i, sig := range signatureList {
+			decodedSig, e := hex.DecodeString(sig)
+			if e != nil {
+				panic(e)
+			}
+
+			s := cipher.Sig{}
+			if len(decodedSig) != len(s) {
+				log.Panic("Invalid signature length")
+			}
+			copy(s[:], decodedSig[:])
+			newTransaction.Sigs[i] = s
+		}
+	}
 	newTransaction.UpdateHeader()
 
 	if err := newTransaction.Verify(); err != nil {
 		panic(err)
 	}
 
-	d := newTransaction.Serialize()
-
-	return hex.EncodeToString(d)
+	return newTransaction
 }

--- a/liteclient/client.go
+++ b/liteclient/client.go
@@ -86,10 +86,9 @@ func PrepareTransactionWithSignatures(inputsBody string, outputsBody string, sig
 	return hex.EncodeToString(d)
 }
 
-// Creates a coin.Transaction using the given lists of inputs, outputs and signatures. If signatureList is nill, the
-// signatures are created using the Secret property of each input.
+// Creates a coin.Transaction using the given lists of inputs, outputs and signatures. If signatureList is nil or
+// empty the signatures are created using the Secret property of each input.
 // inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
-// signatureList is a JSONified array of strings.
 func buildTransaction(inputsBody string, outputsBody string, signatureList []string) coin.Transaction {
 	var inputs []TransactionInput
 	var outputs []TransactionOutput
@@ -107,7 +106,7 @@ func buildTransaction(inputsBody string, outputsBody string, signatureList []str
 	keys := make([]cipher.SecKey, len(inputs))
 
 	for i, in := range inputs {
-		if signatureList == nil {
+		if len(signatureList) == 0 {
 			k, err := cipher.SecKeyFromHex(in.Secret)
 			if err != nil {
 				panic(err)
@@ -137,7 +136,7 @@ func buildTransaction(inputsBody string, outputsBody string, signatureList []str
 		newTransaction.PushOutput(addr, out.Coins, out.Hours)
 	}
 
-	if signatureList == nil {
+	if len(signatureList) == 0 {
 		newTransaction.SignInputs(keys)
 	} else {
 		newTransaction.Sigs = make([]cipher.Sig, len(signatureList))

--- a/skycoin/skycoin.go
+++ b/skycoin/skycoin.go
@@ -9,6 +9,7 @@ func main() {
 	js.Global.Set("Cipher", map[string]interface{}{
 		"GenerateAddresses":  liteclient.GenerateAddress,
 		"PrepareTransaction": liteclient.PrepareTransaction,
+		"PrepareTransactionWithSignatures": liteclient.PrepareTransactionWithSignatures,
 	})
 
 	js.Global.Set("CipherExtras", map[string]interface{}{


### PR DESCRIPTION
This PR adds a new function for creating transactions, which not only receives the inputs and outputs, but also the list of signatures. It was added to create transactions signed with the hardware wallet.