### PR TITLE
Extra functions for the hardware wallet integration

### DIFF
--- a/liteclient/extras.go
+++ b/liteclient/extras.go
@@ -91,3 +91,12 @@ func SignHash(hash string, seckey string) string {
 	sig := cipher.SignHash(h, s)
 	return sig.Hex()
 }
+
+// AddSHA256 returns the SHA256 hash of to two concatenated hashes
+func AddSHA256(hash1 string, hash2 string) string {
+	h1 := cipher.MustSHA256FromHex(hash1)
+	h2 := cipher.MustSHA256FromHex(hash2)
+
+	h := cipher.AddSHA256(h1, h2)
+	return h.Hex()
+}

--- a/skycoin/skycoin.go
+++ b/skycoin/skycoin.go
@@ -7,9 +7,10 @@ import (
 
 func main() {
 	js.Global.Set("Cipher", map[string]interface{}{
-		"GenerateAddresses":  liteclient.GenerateAddress,
-		"PrepareTransaction": liteclient.PrepareTransaction,
+		"GenerateAddresses":                liteclient.GenerateAddress,
+		"PrepareTransaction":               liteclient.PrepareTransaction,
 		"PrepareTransactionWithSignatures": liteclient.PrepareTransactionWithSignatures,
+		"GetTransactionInnerHash":          liteclient.GetTransactionInnerHash,
 	})
 
 	js.Global.Set("CipherExtras", map[string]interface{}{
@@ -22,5 +23,6 @@ func main() {
 		"AddressFromSecKey": liteclient.AddressFromSecKey,
 		"PubKeyFromSig":     liteclient.PubKeyFromSig,
 		"SignHash":          liteclient.SignHash,
+		"AddSHA256":         liteclient.AddSHA256,
 	})
 }


### PR DESCRIPTION
In https://github.com/skycoin/skycoin-lite/pull/27 I made some changes that were necessary for the integration with the hardware wallet. However, when making the changes that were missing in the software wallet to be able to sign the transactions I saw that there were some additional changes neded.

Changes:

- Now it is possible to obtain the inner hash of a transaction just with the inputs and the outputs. This is necessary since the inner hash is part of the data that must be signed by the hardware wallet.

- The `AddSHA256`  function is now accessible from the JS library, to help build the hashes that must be signed by the hardware wallet.

- Now when the function for creating transactions is called including the signatures, the signature list is expected to contain Base58 strings (which is the format returned by the hardware wallet) instead of hex strings.